### PR TITLE
Support args

### DIFF
--- a/redflash/redflash.cpp
+++ b/redflash/redflash.cpp
@@ -824,7 +824,7 @@ int main( int argc, char** argv )
             updateCamera();
 
             // print config
-            std::cout << "resolution: " << width << "x" << height << std::endl;
+            std::cout << "resolution: " << width << "x" << height << " px" << std::endl;
             std::cout << "time_limit: " << time_limit << " sec." << std::endl;
 
             if (use_time_limit)


### PR DESCRIPTION
- sample: Smaple number
- time: Time limit

## outputs

```
C:\Users\gam0022\Dropbox\redflash\build\bin\Release (support-args -> origin)
λ .\redflash.exe -f hoge.png -n -t 20
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/redflash.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/cuda/redflash.cu
[info] getCuStringFromFile source_location: C:/Users/gam0022/Dropbox/redflash/redflash/redflash.cu
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/GrandCanyon_C_YumaPoint/GCanyon_C_YumaPoint_3k.hdr
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/data/GrandCanyon_C_YumaPoint/GCanyon_C_YumaPoint_3k.hdr
[info] resolvePath source_location: C:/Users/gam0022/Dropbox/redflash/data/GrandCanyon_C_YumaPoint/GCanyon_C_YumaPoint_3k.hdr
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/cow.obj
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/data/cow.obj
[info] resolvePath source_location: C:/Users/gam0022/Dropbox/redflash/data/cow.obj
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/triangle_mesh.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/cuda/triangle_mesh.cu
[info] getCuStringFromFile source_location: C:/Users/gam0022/Dropbox/redflash/cuda/triangle_mesh.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/parallelogram.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/cuda/parallelogram.cu
[info] getCuStringFromFile source_location: C:/Users/gam0022/Dropbox/redflash/redflash/parallelogram.cu
resolution: 512x512 px
time_limit: 20 sec.
sample: INF(20)
reached time limit! used_time: 19.8336 sec. remain_time: 0.166351 sec.
sampled: 40
total_time: 19.9432 sec.
```