### PR TITLE
Add param: tonemap_exposure

### DIFF
--- a/redflash/redflash.cpp
+++ b/redflash/redflash.cpp
@@ -95,6 +95,9 @@ Buffer denoisedBuffer;
 Buffer emptyBuffer;
 Buffer trainingDataBuffer;
 
+// Rendering
+float tonemap_exposure = 1.5f;
+
 // Postprocessing‚ÌTonemap‚ð—LŒø‚É‚·‚é‚©‚Ç‚¤‚©
 bool use_post_tonemap = false;
 
@@ -363,6 +366,7 @@ void createContext()
     context["sample_per_launch"]->setUint(sample_per_launch);
     context["total_sample"]->setUint(total_sample);
     context["usePostTonemap"]->setUint(use_post_tonemap);
+    context["tonemap_exposure"]->setFloat(tonemap_exposure);
 
     Buffer output_buffer = sutil::createOutputBuffer(context, RT_FORMAT_FLOAT4, width, height, use_pbo);
     context["output_buffer"]->set(output_buffer);
@@ -451,7 +455,7 @@ void setupPostprocessing()
             tonemapStage = context->createBuiltinPostProcessingStage("TonemapperSimple");
             tonemapStage->declareVariable("input_buffer")->set(getOutputBuffer());
             tonemapStage->declareVariable("output_buffer")->set(getTonemappedBuffer());
-            tonemapStage->declareVariable("exposure")->setFloat(2.00f);
+            tonemapStage->declareVariable("exposure")->setFloat(tonemap_exposure);
             tonemapStage->declareVariable("gamma")->setFloat(2.2f);
         }
 
@@ -1340,6 +1344,15 @@ int main(int argc, char** argv)
             }
             auto_set_sample_per_launch = true;
             auto_set_sample_per_launch_scale = atof(argv[++i]);
+        }
+        else if (arg == "--tonemap_exposure")
+        {
+            if (i == argc - 1)
+            {
+                std::cerr << "Option '" << arg << "' requires additional argument.\n";
+                printUsageAndExit(argv[0]);
+            }
+            tonemap_exposure = atof(argv[++i]);
         }
         else if (arg.find("-d") == 0 || arg.find("--dim") == 0)
         {

--- a/redflash/redflash.cu
+++ b/redflash/redflash.cu
@@ -64,6 +64,7 @@ rtDeclareVariable(unsigned int, sample_per_launch, , );
 rtDeclareVariable(unsigned int, rr_begin_depth, , );
 rtDeclareVariable(unsigned int, max_depth, , );
 rtDeclareVariable(unsigned int, use_post_tonemap, , );
+rtDeclareVariable(float, tonemap_exposure, , );
 
 rtBuffer<float4, 2> output_buffer;
 rtBuffer<float4, 2> liner_buffer;
@@ -175,7 +176,7 @@ RT_PROGRAM void pathtrace_camera()
         // pixel_normal = lerp(make_float3(input_normal_buffer[launch_index]), pixel_normal, a);
     }
 
-    float3 pixel_output = use_post_tonemap ? pixel_liner : linear_to_sRGB(tonemap_acesFilm(pixel_liner));
+    float3 pixel_output = use_post_tonemap ? pixel_liner : linear_to_sRGB(tonemap_acesFilm(pixel_liner * tonemap_exposure));
 
     // Save to buffer
     liner_buffer[launch_index] = make_float4(pixel_liner, 1.0);


### PR DESCRIPTION
![pr31_v1](https://user-images.githubusercontent.com/759115/64126396-850f7400-cde8-11e9-8499-be16d092bfb5.png)

![pr31_v1 png_original](https://user-images.githubusercontent.com/759115/64126404-948ebd00-cde8-11e9-9fb7-6ea7a520cce0.png)

```
C:\Users\gam0022\Dropbox\redflash\build\bin\Release (tonema-exposure -> origin)
λ .\redflash.exe -f pr31_v1.png -W 1920 -H 1080 -t 57 -A 1.0 -S 4 --debug
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/redflash.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/cuda/redflash.cu
[info] getCuStringFromFile source_location: C:/Users/gam0022/Dropbox/redflash/redflash/redflash.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/intersect_raymarching.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/cuda/intersect_raymarching.cu
[info] getCuStringFromFile source_location: C:/Users/gam0022/Dropbox/redflash/redflash/intersect_raymarching.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/intersect_sphere.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/cuda/intersect_sphere.cu
[info] getCuStringFromFile source_location: C:/Users/gam0022/Dropbox/redflash/redflash/intersect_sphere.cu
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/cow.obj
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/data/cow.obj
[info] resolvePath source_location: C:/Users/gam0022/Dropbox/redflash/data/cow.obj
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/triangle_mesh.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/cuda/triangle_mesh.cu
[info] getCuStringFromFile source_location: C:/Users/gam0022/Dropbox/redflash/cuda/triangle_mesh.cu
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/metallic-lucy-statue-stanford-scan.obj
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/data/metallic-lucy-statue-stanford-scan.obj
[info] resolvePath source_location: C:/Users/gam0022/Dropbox/redflash/data/metallic-lucy-statue-stanford-scan.obj
WARN: Material file [ C:/Users/gam0022/Dropbox/redflash/data/metallic-lucy-statue-stanford-scan.mtl ] not found. Created a default material.
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/Ice_Lake/Ice_Lake_Ref.hdr
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/data/Ice_Lake/Ice_Lake_Ref.hdr
[info] resolvePath source_location: C:/Users/gam0022/Dropbox/redflash/data/Ice_Lake/Ice_Lake_Ref.hdr
[info] resolution: 1920x1080 px
[info] time_limit: 57 sec.
[info] sample_per_launch: 4
[info] auto_set_sample_per_launch: 1
[info] auto_set_sample_per_launch_scale: 1
[info] sample: INF(20)
loop:0sample_per_launch :4      delta_time:1.00001e-07  delta_time_per_sample:2.50002e-08       used_time:1.76619       remain_time:55.2338     sample:0        frame_number:1
loop:1sample_per_launch :4      delta_time:2.97723      delta_time_per_sample:0.744306  used_time:4.74342       remain_time:52.2566     sample:4        frame_number:2
[info] chnage sample_per_launch: 70 to 70
loop:2sample_per_launch :70     delta_time:37.1689      delta_time_per_sample:0.530984  used_time:41.9123       remain_time:15.0877     sample:74       frame_number:3
[info] chnage sample_per_launch: 70 to 1
loop:3sample_per_launch :1      delta_time:0.660252     delta_time_per_sample:0.660252  used_time:42.5726       remain_time:14.4274     sample:75       frame_number:4
loop:4sample_per_launch :1      delta_time:0.615572     delta_time_per_sample:0.615572  used_time:43.1881       remain_time:13.8119     sample:76       frame_number:5
loop:5sample_per_launch :1      delta_time:0.605673     delta_time_per_sample:0.605673  used_time:43.7938       remain_time:13.2062     sample:77       frame_number:6
loop:6sample_per_launch :1      delta_time:0.610857     delta_time_per_sample:0.610857  used_time:44.4047       remain_time:12.5953     sample:78       frame_number:7
loop:7sample_per_launch :1      delta_time:0.615072     delta_time_per_sample:0.615072  used_time:45.0197       remain_time:11.9803     sample:79       frame_number:8
loop:8sample_per_launch :1      delta_time:0.641031     delta_time_per_sample:0.641031  used_time:45.6608       remain_time:11.3392     sample:80       frame_number:9
loop:9sample_per_launch :1      delta_time:0.57831      delta_time_per_sample:0.57831   used_time:46.2391       remain_time:10.7609     sample:81       frame_number:10
loop:10sample_per_launch        :1      delta_time:0.696484     delta_time_per_sample:0.696484  used_time:46.9356       remain_time:10.0644     sample:82       frame_number:11
loop:11sample_per_launch        :1      delta_time:0.641783     delta_time_per_sample:0.641783  used_time:47.5774       remain_time:9.42265     sample:83       frame_number:12
loop:12sample_per_launch        :1      delta_time:0.764245     delta_time_per_sample:0.764245  used_time:48.3416       remain_time:8.6584      sample:84       frame_number:13
loop:13sample_per_launch        :1      delta_time:0.802946     delta_time_per_sample:0.802946  used_time:49.1445       remain_time:7.85546     sample:85       frame_number:14
loop:14sample_per_launch        :1      delta_time:0.722585     delta_time_per_sample:0.722585  used_time:49.8671       remain_time:7.13287     sample:86       frame_number:15
loop:15sample_per_launch        :1      delta_time:0.727915     delta_time_per_sample:0.727915  used_time:50.595        remain_time:6.40495     sample:87       frame_number:16
loop:16sample_per_launch        :1      delta_time:0.710425     delta_time_per_sample:0.710425  used_time:51.3055       remain_time:5.69453     sample:88       frame_number:17
loop:17sample_per_launch        :1      delta_time:0.721352     delta_time_per_sample:0.721352  used_time:52.0268       remain_time:4.97318     sample:89       frame_number:18
loop:18sample_per_launch        :1      delta_time:0.717944     delta_time_per_sample:0.717944  used_time:52.7448       remain_time:4.25523     sample:90       frame_number:19
loop:19sample_per_launch        :1      delta_time:0.66185      delta_time_per_sample:0.66185   used_time:53.4066       remain_time:3.59338     sample:91       frame_number:20
loop:20sample_per_launch        :1      delta_time:0.74609      delta_time_per_sample:0.74609   used_time:54.1527       remain_time:2.84729     sample:92       frame_number:21
loop:21sample_per_launch        :1      delta_time:0.739731     delta_time_per_sample:0.739731  used_time:54.8924       remain_time:2.10756     sample:93       frame_number:22
loop:22sample_per_launch        :1      delta_time:0.710369     delta_time_per_sample:0.710369  used_time:55.6028       remain_time:1.39719     sample:94       frame_number:23
loop:23sample_per_launch        :1      delta_time:0.751425     delta_time_per_sample:0.751425  used_time:56.3542       remain_time:0.645768    sample:95       frame_number:24
[info] reached time limit! used_time: 56.3542 sec. remain_time: 0.645768 sec.
[info] total_time: 60.0354 sec.
[info] total_sample: 95
```