### PR TITLE
Mesure PNG Save and Final Rendering

### DIFF
--- a/redflash/redflash.cpp
+++ b/redflash/redflash.cpp
@@ -63,6 +63,7 @@ int frame_number = 1;
 int total_sample = 0;
 bool auto_set_sample_per_launch = false;
 double auto_set_sample_per_launch_scale = 0.95;
+double last_frame_scale = 1.7;
 
 // Intersect Programs
 Program pgram_intersection = 0;
@@ -1366,6 +1367,15 @@ int main(int argc, char** argv)
             auto_set_sample_per_launch = true;
             auto_set_sample_per_launch_scale = atof(argv[++i]);
         }
+        else if (arg == "--last_frame_scale")
+        {
+            if (i == argc - 1)
+            {
+                std::cerr << "Option '" << arg << "' requires additional argument.\n";
+                printUsageAndExit(argv[0]);
+            }
+            last_frame_scale = atof(argv[++i]);
+        }
         else if (arg == "--tonemap_exposure")
         {
             if (i == argc - 1)
@@ -1512,6 +1522,9 @@ int main(int argc, char** argv)
             std::cout << "[info] sample_per_launch: " << sample_per_launch << std::endl;
             std::cout << "[info] auto_set_sample_per_launch: " << auto_set_sample_per_launch << std::endl;
             std::cout << "[info] auto_set_sample_per_launch_scale: " << auto_set_sample_per_launch_scale << std::endl;
+            std::cout << "[info] last_frame_scale: " << last_frame_scale << std::endl;
+            std::cout << "[info] tonemap_exposure: " << tonemap_exposure << std::endl;
+
 
             if (use_time_limit)
             {
@@ -1546,8 +1559,8 @@ int main(int argc, char** argv)
                     std::cout << "[info] chnage sample_per_launch: " << sample_per_launch << " to " << sample_per_launch << std::endl;
                 }
 
-                // NOTE: 前フレームの所要時間から次のフレームが制限時間内に終るかを予測する。時間超過を防ぐために1.1倍に見積もる
-                if (used_time + delta_time * 1.1 > time_limit)
+                // NOTE: 前フレームの所要時間から次のフレームが制限時間内に終るかを予測する。デノイズを考慮して last_frame_scale 倍に見積もる
+                if (used_time + delta_time * last_frame_scale > time_limit)
                 {
                     if (sample_per_launch == 1)
                     {


### PR DESCRIPTION
## 4K

```
C:\Users\gam0022\Dropbox\redflash\build\bin\Release (mesure-png-save -> origin)
λ .\redflash.exe -f pr34_4k.png -W 3840 -H 2160 -t 57 -A 1.0 -S 4 --debug --denoise_mode 2
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/redflash.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/cuda/redflash.cu
[info] getCuStringFromFile source_location: C:/Users/gam0022/Dropbox/redflash/redflash/redflash.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/intersect_raymarching.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/cuda/intersect_raymarching.cu
[info] getCuStringFromFile source_location: C:/Users/gam0022/Dropbox/redflash/redflash/intersect_raymarching.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/intersect_sphere.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/cuda/intersect_sphere.cu
[info] getCuStringFromFile source_location: C:/Users/gam0022/Dropbox/redflash/redflash/intersect_sphere.cu
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/cow.obj
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/data/cow.obj
[info] resolvePath source_location: C:/Users/gam0022/Dropbox/redflash/data/cow.obj
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/triangle_mesh.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/cuda/triangle_mesh.cu
[info] getCuStringFromFile source_location: C:/Users/gam0022/Dropbox/redflash/cuda/triangle_mesh.cu
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/metallic-lucy-statue-stanford-scan.obj
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/data/metallic-lucy-statue-stanford-scan.obj
[info] resolvePath source_location: C:/Users/gam0022/Dropbox/redflash/data/metallic-lucy-statue-stanford-scan.obj
WARN: Material file [ C:/Users/gam0022/Dropbox/redflash/data/metallic-lucy-statue-stanford-scan.mtl ] not found. Created a default material.
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/Ice_Lake/Ice_Lake_Ref.hdr
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/data/Ice_Lake/Ice_Lake_Ref.hdr
[info] resolvePath source_location: C:/Users/gam0022/Dropbox/redflash/data/Ice_Lake/Ice_Lake_Ref.hdr
[info] resolution: 3840x2160 px
[info] time_limit: 57 sec.
[info] sample_per_launch: 4
[info] auto_set_sample_per_launch: 1
[info] auto_set_sample_per_launch_scale: 1
[info] sample: INF(20)
loop:0  sample_per_launch       :4      delta_time:1.00001e-07  delta_time_per_sample:2.50002e-08       used_time:1.65338       remain_time:55.3466     sample:0        frame_number:1
loop:1  sample_per_launch       :4      delta_time:8.55461      delta_time_per_sample:2.13865   used_time:10.208        remain_time:46.792      sample:4        frame_number:2
[info] chnage sample_per_launch: 21 to 21
loop:2  sample_per_launch       :21     delta_time:42.6537      delta_time_per_sample:2.03113   used_time:52.8617       remain_time:4.13829     sample:25       frame_number:3
[info] chnage sample_per_launch: 21 to 1
loop:3  sample_per_launch       :1      delta_time:2.19313      delta_time_per_sample:2.19313   used_time:55.0548       remain_time:1.94516     sample:26       frame_number:4
[info] reached time limit! used_time: 55.0548 sec. remain_time: 1.94516 sec.
[info] final_frame_rendering: 3.58042 sec.
[info] save_png: pr34_4k.png    1.64461 sec.
[info] save_png: pr34_4k.png_original.png       1.66721 sec.
[info] save_png: pr34_4k.png_albedo.png 0.559299 sec.
[info] save_png: pr34_4k.png_normal.png 1.75106 sec.
[info] save_png: pr34_4k.png_liner.png  1.51867 sec.
[info] total_time: 65.9087 sec.
[info] total_sample: 27
```

3.58042/2.19313 = 1.63256168125

通常のレンダリングよりもデノイズありだと1.7倍くらいかかると見積もったほうが安全。

逆に言うと4K解像度でも 3.58042-2.19313 = 1.38729 秒程度でデノイズが完了する。

PNGの保存も2秒くらいかかる可能性がありそう

```
[info] resolution: 3840x2160 px
[info] time_limit: 57 sec.
[info] sample_per_launch: 4
[info] auto_set_sample_per_launch: 1
[info] auto_set_sample_per_launch_scale: 1
[info] sample: INF(20)
loop:0  sample_per_launch       :4      delta_time:1.00001e-07  delta_time_per_sample:2.50002e-08       used_time:1.65446       remain_time:55.3455     sample:0        frame_number:1
loop:1  sample_per_launch       :4      delta_time:8.59768      delta_time_per_sample:2.14942   used_time:10.2521       remain_time:46.7479     sample:4        frame_number:2
[info] chnage sample_per_launch: 21 to 21
loop:2  sample_per_launch       :21     delta_time:44.8975      delta_time_per_sample:2.13798   used_time:55.1496       remain_time:1.85036     sample:25       frame_number:3
[info] chnage sample_per_launch: 21 to 1
loop:3  sample_per_launch       :1      delta_time:2.25697      delta_time_per_sample:2.25697   used_time:57.4066       remain_time:-0.406607   sample:26       frame_number:4
[info] reached time limit! used_time: 57.4066 sec. remain_time: -0.406607 sec.
[info] final_frame_rendering: 3.68826 sec.
[info] save_png: pr34_4k_try2.png       1.68355 sec.
[info] save_png: pr34_4k_try2.png_original.png  1.75526 sec.
[info] save_png: pr34_4k_try2.png_albedo.png    0.567646 sec.
[info] save_png: pr34_4k_try2.png_normal.png    1.83439 sec.
[info] save_png: pr34_4k_try2.png_liner.png     1.62927 sec.
[info] total_time: 68.7166 sec.
[info] total_sample: 27
```

3.68826/2.25697 = 1.63416438854

## 1K

```
C:\Users\gam0022\Dropbox\redflash\build\bin\Release (mesure-png-save -> origin)
λ .\redflash.exe -f pr34_1k.png -W 1920 -H 1080 -t 57 -A 1.0 -S 4 --debug --denoise_mode 2
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/redflash.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/cuda/redflash.cu
[info] getCuStringFromFile source_location: C:/Users/gam0022/Dropbox/redflash/redflash/redflash.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/intersect_raymarching.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/cuda/intersect_raymarching.cu
[info] getCuStringFromFile source_location: C:/Users/gam0022/Dropbox/redflash/redflash/intersect_raymarching.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/intersect_sphere.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/cuda/intersect_sphere.cu
[info] getCuStringFromFile source_location: C:/Users/gam0022/Dropbox/redflash/redflash/intersect_sphere.cu
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/cow.obj
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/data/cow.obj
[info] resolvePath source_location: C:/Users/gam0022/Dropbox/redflash/data/cow.obj
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/triangle_mesh.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/cuda/triangle_mesh.cu
[info] getCuStringFromFile source_location: C:/Users/gam0022/Dropbox/redflash/cuda/triangle_mesh.cu
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/metallic-lucy-statue-stanford-scan.obj
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/data/metallic-lucy-statue-stanford-scan.obj
[info] resolvePath source_location: C:/Users/gam0022/Dropbox/redflash/data/metallic-lucy-statue-stanford-scan.obj
WARN: Material file [ C:/Users/gam0022/Dropbox/redflash/data/metallic-lucy-statue-stanford-scan.mtl ] not found. Created a default material.
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/Ice_Lake/Ice_Lake_Ref.hdr
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/data/Ice_Lake/Ice_Lake_Ref.hdr
[info] resolvePath source_location: C:/Users/gam0022/Dropbox/redflash/data/Ice_Lake/Ice_Lake_Ref.hdr
[info] resolution: 1920x1080 px
[info] time_limit: 57 sec.
[info] sample_per_launch: 4
[info] auto_set_sample_per_launch: 1
[info] auto_set_sample_per_launch_scale: 1
[info] sample: INF(20)
loop:0  sample_per_launch       :4      delta_time:1.00001e-07  delta_time_per_sample:2.50002e-08       used_time:2.26255       remain_time:54.7375     sample:0        frame_number:1
loop:1  sample_per_launch       :4      delta_time:2.41386      delta_time_per_sample:0.603464  used_time:4.6764        remain_time:52.3236     sample:4        frame_number:2
[info] chnage sample_per_launch: 86 to 86
loop:2  sample_per_launch       :86     delta_time:45.9252      delta_time_per_sample:0.534015  used_time:50.6017       remain_time:6.39835     sample:90       frame_number:3
[info] chnage sample_per_launch: 86 to 1
loop:3  sample_per_launch       :1      delta_time:0.551421     delta_time_per_sample:0.551421  used_time:51.1531       remain_time:5.84693     sample:91       frame_number:4
loop:4  sample_per_launch       :1      delta_time:0.552094     delta_time_per_sample:0.552094  used_time:51.7052       remain_time:5.29484     sample:92       frame_number:5
loop:5  sample_per_launch       :1      delta_time:0.615832     delta_time_per_sample:0.615832  used_time:52.321        remain_time:4.679       sample:93       frame_number:6
loop:6  sample_per_launch       :1      delta_time:0.553717     delta_time_per_sample:0.553717  used_time:52.8747       remain_time:4.12529     sample:94       frame_number:7
loop:7  sample_per_launch       :1      delta_time:0.583498     delta_time_per_sample:0.583498  used_time:53.4582       remain_time:3.54179     sample:95       frame_number:8
loop:8  sample_per_launch       :1      delta_time:0.558195     delta_time_per_sample:0.558195  used_time:54.0164       remain_time:2.98359     sample:96       frame_number:9
loop:9  sample_per_launch       :1      delta_time:0.681235     delta_time_per_sample:0.681235  used_time:54.6976       remain_time:2.30236     sample:97       frame_number:10
loop:10 sample_per_launch       :1      delta_time:0.556701     delta_time_per_sample:0.556701  used_time:55.2543       remain_time:1.74566     sample:98       frame_number:11
loop:11 sample_per_launch       :1      delta_time:0.547785     delta_time_per_sample:0.547785  used_time:55.8021       remain_time:1.19787     sample:99       frame_number:12
loop:12 sample_per_launch       :1      delta_time:0.603266     delta_time_per_sample:0.603266  used_time:56.4054       remain_time:0.594607    sample:100      frame_number:13
[info] reached time limit! used_time: 56.4054 sec. remain_time: 0.594607 sec.
[info] final_frame_rendering: 2.7319 sec.
[info] save_png: pr34_1k.png    0.516653 sec.
[info] save_png: pr34_1k.png_original.png       0.42555 sec.
[info] save_png: pr34_1k.png_albedo.png 0.133429 sec.
[info] save_png: pr34_1k.png_normal.png 0.428868 sec.
[info] save_png: pr34_1k.png_liner.png  0.395824 sec.
[info] total_time: 61.1253 sec.
[info] total_sample: 101
```

デノイズありだと
2.7319/0.594607 = 4.52851644217 倍

デノイズの時間は 2.7319-0.594607 = 2.137293 秒なので、むしろ4Kより時間がかかる？？

```
loop:7  sample_per_launch       :1      delta_time:0.549091     delta_time_per_sample:0.549091  used_time:55.2593       remain_time:1.74066     sample:102      frame_number:8
loop:8  sample_per_launch       :1      delta_time:0.553152     delta_time_per_sample:0.553152  used_time:55.8125       remain_time:1.18751     sample:103      frame_number:9
loop:9  sample_per_launch       :1      delta_time:0.571335     delta_time_per_sample:0.571335  used_time:56.3838       remain_time:0.616172    sample:104      frame_number:10
[info] reached time limit! used_time: 56.3838 sec. remain_time: 0.616172 sec.
[info] final_frame_rendering: 2.5951 sec.
[info] save_png: pr34_4k_try2.png       0.435972 sec.
[info] save_png: pr34_4k_try2.png_original.png  0.427254 sec.
[info] save_png: pr34_4k_try2.png_albedo.png    0.141144 sec.
[info] save_png: pr34_4k_try2.png_normal.png    0.452725 sec.
[info] save_png: pr34_4k_try2.png_liner.png     0.39141 sec.
[info] total_time: 60.8965 sec.
[info] total_sample: 105
```

2.5951/0.616172 = 4.21164869549

2.5951-0.616172 = 1.978928