### PR TITLE
Always Disable RT_BUFFER_GPU_LOCAL

### DIFF
--- a/redflash/redflash.cpp
+++ b/redflash/redflash.cpp
@@ -372,37 +372,18 @@ void createContext()
     Buffer output_buffer = sutil::createOutputBuffer(context, RT_FORMAT_FLOAT4, width, height, use_pbo);
     context["output_buffer"]->set(output_buffer);
 
-    if (use_pbo || true)
-    {
-        Buffer liner_buffer = sutil::createInputOutputBuffer(context, RT_FORMAT_FLOAT4, width, height, use_pbo);
-        context["liner_buffer"]->set(liner_buffer);
+    Buffer liner_buffer = sutil::createInputOutputBuffer(context, RT_FORMAT_FLOAT4, width, height, use_pbo);
+    context["liner_buffer"]->set(liner_buffer);
 
-        Buffer tonemappedBuffer = sutil::createInputOutputBuffer(context, RT_FORMAT_FLOAT4, width, height, use_pbo);
-        context["tonemapped_buffer"]->set(tonemappedBuffer);
+    Buffer tonemappedBuffer = sutil::createInputOutputBuffer(context, RT_FORMAT_FLOAT4, width, height, use_pbo);
+    context["tonemapped_buffer"]->set(tonemappedBuffer);
 
-        Buffer albedoBuffer = sutil::createInputOutputBuffer(context, RT_FORMAT_FLOAT4, width, height, use_pbo);
-        context["input_albedo_buffer"]->set(albedoBuffer);
+    Buffer albedoBuffer = sutil::createInputOutputBuffer(context, RT_FORMAT_FLOAT4, width, height, use_pbo);
+    context["input_albedo_buffer"]->set(albedoBuffer);
 
-        // The normal buffer use float4 for performance reasons, the fourth channel will be ignored.
-        Buffer normalBuffer = sutil::createInputOutputBuffer(context, RT_FORMAT_FLOAT4, width, height, use_pbo);
-        context["input_normal_buffer"]->set(normalBuffer);
-    }
-    else
-    {
-        // NOTE: RT_BUFFER_GPU_LOCALの方ががパフォーマンスが向上するので、ウィンドウ出さないならこっちを使う
-        Buffer liner_buffer = context->createBuffer(RT_BUFFER_INPUT_OUTPUT | RT_BUFFER_GPU_LOCAL, RT_FORMAT_FLOAT4, width, height);
-        context["liner_buffer"]->set(liner_buffer);
-
-        Buffer tonemappedBuffer = context->createBuffer(RT_BUFFER_INPUT_OUTPUT | RT_BUFFER_GPU_LOCAL, RT_FORMAT_FLOAT4, width, height);
-        context["tonemapped_buffer"]->set(tonemappedBuffer);
-
-        Buffer albedoBuffer = context->createBuffer(RT_BUFFER_INPUT_OUTPUT | RT_BUFFER_GPU_LOCAL, RT_FORMAT_FLOAT4, width, height);
-        context["input_albedo_buffer"]->set(albedoBuffer);
-
-        // The normal buffer use float4 for performance reasons, the fourth channel will be ignored.
-        Buffer normalBuffer = context->createBuffer(RT_BUFFER_INPUT_OUTPUT | RT_BUFFER_GPU_LOCAL, RT_FORMAT_FLOAT4, width, height);
-        context["input_normal_buffer"]->set(normalBuffer);
-    }
+    // The normal buffer use float4 for performance reasons, the fourth channel will be ignored.
+    Buffer normalBuffer = sutil::createInputOutputBuffer(context, RT_FORMAT_FLOAT4, width, height, use_pbo);
+    context["input_normal_buffer"]->set(normalBuffer);
 
     denoisedBuffer = sutil::createOutputBuffer(context, RT_FORMAT_FLOAT4, width, height, use_pbo);
     emptyBuffer = context->createBuffer(RT_BUFFER_OUTPUT, RT_FORMAT_FLOAT4, 0, 0);

--- a/redflash/redflash.cpp
+++ b/redflash/redflash.cpp
@@ -372,7 +372,7 @@ void createContext()
     Buffer output_buffer = sutil::createOutputBuffer(context, RT_FORMAT_FLOAT4, width, height, use_pbo);
     context["output_buffer"]->set(output_buffer);
 
-    if (use_pbo)
+    if (use_pbo || true)
     {
         Buffer liner_buffer = sutil::createInputOutputBuffer(context, RT_FORMAT_FLOAT4, width, height, use_pbo);
         context["liner_buffer"]->set(liner_buffer);


### PR DESCRIPTION
複数GPU環境だと `RT_BUFFER_GPU_LOCAL` は問題が起きるようでした…

RTX2070 1枚 や p3.2xlarge だと全く問題ないのに、p3.16xlarge だと一部しか描画されませんでした。

GitHubにアップロード用にファイルを縮小するために 4K解像度からFullHD 解像度に 50% リサイズ

```
mogrify -resize 50% *.png
```

# 検証環境: p3.16xlarge

## bofore（レイトレ合宿7 提出版）--debug 1回目

### output

![output](https://user-images.githubusercontent.com/759115/65371870-2e88ad80-dca3-11e9-9f87-399b3642cd5e.png)

### output png_albedo

![output png_albedo](https://user-images.githubusercontent.com/759115/65371872-32b4cb00-dca3-11e9-91d2-f29a1654d0ec.png)

### output png_liner

![output png_liner](https://user-images.githubusercontent.com/759115/65371876-3f392380-dca3-11e9-847c-a58af4e618d8.png)

### output png_normal

![output png_normal](https://user-images.githubusercontent.com/759115/65371880-524bf380-dca3-11e9-856e-90c34e4c5397.png)

### output png_original

![output png_original](https://user-images.githubusercontent.com/759115/65371885-6132a600-dca3-11e9-86ec-ae651d14d928.png)

### output.log

[info] total_time: 79.5578 sec.
[info] total_sample: 16

<details>
<summary>output.log</summary>
<pre>
<code>
[info] getCuStringFromFile source_location: C:\Users\Administrator\Desktop\redflash_submit_v3.3\redflash_submit/redflash.cu
[info] getCuStringFromFile source_location: C:\Users\Administrator\Desktop\redflash_submit_v3.3\redflash_submit/cuda/redflash.cu
[info] getCuStringFromFile source_location: C:\Users\Administrator\Desktop\redflash_submit_v3.3\redflash_submit/intersect_raymarching.cu
[info] getCuStringFromFile source_location: C:\Users\Administrator\Desktop\redflash_submit_v3.3\redflash_submit/cuda/intersect_raymarching.cu
[info] getCuStringFromFile source_location: C:\Users\Administrator\Desktop\redflash_submit_v3.3\redflash_submit/intersect_sphere.cu
[info] getCuStringFromFile source_location: C:\Users\Administrator\Desktop\redflash_submit_v3.3\redflash_submit/cuda/intersect_sphere.cu
[info] resolvePath source_location: C:\Users\Administrator\Desktop\redflash_submit_v3.3\redflash_submit/cow.obj
[info] resolvePath source_location: C:\Users\Administrator\Desktop\redflash_submit_v3.3\redflash_submit/data/cow.obj
[info] getCuStringFromFile source_location: C:\Users\Administrator\Desktop\redflash_submit_v3.3\redflash_submit/triangle_mesh.cu
[info] getCuStringFromFile source_location: C:\Users\Administrator\Desktop\redflash_submit_v3.3\redflash_submit/cuda/triangle_mesh.cu
[info] resolvePath source_location: C:\Users\Administrator\Desktop\redflash_submit_v3.3\redflash_submit/metallic-lucy-statue-stanford-scan.obj
[info] resolvePath source_location: C:\Users\Administrator\Desktop\redflash_submit_v3.3\redflash_submit/data/metallic-lucy-statue-stanford-scan.obj
[info] resolvePath source_location: C:\Users\Administrator\Desktop\redflash_submit_v3.3\redflash_submit/Ice_Lake/Ice_Lake_Ref.hdr
[info] resolvePath source_location: C:\Users\Administrator\Desktop\redflash_submit_v3.3\redflash_submit/data/Ice_Lake/Ice_Lake_Ref.hdr
[info] resolution: 3840x2160 px
[info] time_limit: 53 sec.
[info] sample_per_launch: 4
[info] auto_set_sample_per_launch: 1
[info] auto_set_sample_per_launch_scale: 1
[info] sample: INF(20)
loop:0	sample_per_launch	:4	delta_time:4.45208e-07	delta_time_per_sample:1.11302e-07	used_time:46.5242	remain_time:6.47579	sample:0	frame_number:1
loop:1	sample_per_launch	:4	delta_time:3.47416	delta_time_per_sample:0.868541	used_time:49.9984	remain_time:3.00162	sample:4	frame_number:2
[info] chnage sample_per_launch: 3 to 3
[info] chnage sample_per_launch: 3 to 1
loop:2	sample_per_launch	:1	delta_time:0.254855	delta_time_per_sample:0.254855	used_time:50.2532	remain_time:2.74677	sample:5	frame_number:3
loop:3	sample_per_launch	:1	delta_time:0.244033	delta_time_per_sample:0.244033	used_time:50.4973	remain_time:2.50274	sample:6	frame_number:4
loop:4	sample_per_launch	:1	delta_time:0.250411	delta_time_per_sample:0.250411	used_time:50.7477	remain_time:2.25233	sample:7	frame_number:5
loop:5	sample_per_launch	:1	delta_time:0.257982	delta_time_per_sample:0.257982	used_time:51.0057	remain_time:1.99434	sample:8	frame_number:6
loop:6	sample_per_launch	:1	delta_time:0.257754	delta_time_per_sample:0.257754	used_time:51.2634	remain_time:1.73659	sample:9	frame_number:7
loop:7	sample_per_launch	:1	delta_time:0.248163	delta_time_per_sample:0.248163	used_time:51.5116	remain_time:1.48843	sample:10	frame_number:8
loop:8	sample_per_launch	:1	delta_time:0.242698	delta_time_per_sample:0.242698	used_time:51.7543	remain_time:1.24573	sample:11	frame_number:9
loop:9	sample_per_launch	:1	delta_time:0.244708	delta_time_per_sample:0.244708	used_time:51.999	remain_time:1.00102	sample:12	frame_number:10
loop:10	sample_per_launch	:1	delta_time:0.242921	delta_time_per_sample:0.242921	used_time:52.2419	remain_time:0.758101	sample:13	frame_number:11
loop:11	sample_per_launch	:1	delta_time:0.242243	delta_time_per_sample:0.242243	used_time:52.4841	remain_time:0.515857	sample:14	frame_number:12
loop:12	sample_per_launch	:1	delta_time:0.256726	delta_time_per_sample:0.256726	used_time:52.7409	remain_time:0.259131	sample:15	frame_number:13
[info] reached time limit! used_time: 52.7409 sec. remain_time: 0.259131 sec.
[info] total_time: 79.5578 sec.
[info] total_sample: 16

</code>
</pre>
</details>

### rtcamp7.bat

```
.\redflash.exe -f output.png -W 3840 -H 2160 -t 53 -A 1.0 -S 4 --denoise_mode 2 --debug > output.txt
```

## bofore（レイトレ合宿7 提出版）--debug 2回目

![output](https://user-images.githubusercontent.com/759115/65372025-6395ff80-dca5-11e9-9f9e-5d7fcf2621f2.png)

![output png_albedo](https://user-images.githubusercontent.com/759115/65372026-65f85980-dca5-11e9-8047-24f184ad832a.png)

![output png_liner](https://user-images.githubusercontent.com/759115/65372027-685ab380-dca5-11e9-971a-e6ea6c6511d0.png)

![output png_normal](https://user-images.githubusercontent.com/759115/65372028-6c86d100-dca5-11e9-9657-02bc9aba3ca2.png)

![output png_original](https://user-images.githubusercontent.com/759115/65372030-6f81c180-dca5-11e9-80fb-dbb20599c984.png)

### output.log

[info] total_time: 78.2971 sec.
[info] total_sample: 124

<details>
<summary>output.log</summary>
<pre>
<code>
[info] getCuStringFromFile source_location: C:\Users\Administrator\Desktop\redflash_submit_v3.3\redflash_submit/redflash.cu
[info] getCuStringFromFile source_location: C:\Users\Administrator\Desktop\redflash_submit_v3.3\redflash_submit/cuda/redflash.cu
[info] getCuStringFromFile source_location: C:\Users\Administrator\Desktop\redflash_submit_v3.3\redflash_submit/intersect_raymarching.cu
[info] getCuStringFromFile source_location: C:\Users\Administrator\Desktop\redflash_submit_v3.3\redflash_submit/cuda/intersect_raymarching.cu
[info] getCuStringFromFile source_location: C:\Users\Administrator\Desktop\redflash_submit_v3.3\redflash_submit/intersect_sphere.cu
[info] getCuStringFromFile source_location: C:\Users\Administrator\Desktop\redflash_submit_v3.3\redflash_submit/cuda/intersect_sphere.cu
[info] resolvePath source_location: C:\Users\Administrator\Desktop\redflash_submit_v3.3\redflash_submit/cow.obj
[info] resolvePath source_location: C:\Users\Administrator\Desktop\redflash_submit_v3.3\redflash_submit/data/cow.obj
[info] getCuStringFromFile source_location: C:\Users\Administrator\Desktop\redflash_submit_v3.3\redflash_submit/triangle_mesh.cu
[info] getCuStringFromFile source_location: C:\Users\Administrator\Desktop\redflash_submit_v3.3\redflash_submit/cuda/triangle_mesh.cu
[info] resolvePath source_location: C:\Users\Administrator\Desktop\redflash_submit_v3.3\redflash_submit/metallic-lucy-statue-stanford-scan.obj
[info] resolvePath source_location: C:\Users\Administrator\Desktop\redflash_submit_v3.3\redflash_submit/data/metallic-lucy-statue-stanford-scan.obj
[info] resolvePath source_location: C:\Users\Administrator\Desktop\redflash_submit_v3.3\redflash_submit/Ice_Lake/Ice_Lake_Ref.hdr
[info] resolvePath source_location: C:\Users\Administrator\Desktop\redflash_submit_v3.3\redflash_submit/data/Ice_Lake/Ice_Lake_Ref.hdr
[info] resolution: 3840x2160 px
[info] time_limit: 53 sec.
[info] sample_per_launch: 4
[info] auto_set_sample_per_launch: 1
[info] auto_set_sample_per_launch_scale: 1
[info] sample: INF(20)
loop:0	sample_per_launch	:4	delta_time:4.45208e-07	delta_time_per_sample:1.11302e-07	used_time:31.3158	remain_time:21.6842	sample:0	frame_number:1
loop:1	sample_per_launch	:4	delta_time:3.21881	delta_time_per_sample:0.804701	used_time:34.5346	remain_time:18.4654	sample:4	frame_number:2
[info] chnage sample_per_launch: 22 to 22
loop:2	sample_per_launch	:22	delta_time:3.18106	delta_time_per_sample:0.144594	used_time:37.7157	remain_time:15.2843	sample:26	frame_number:3
loop:3	sample_per_launch	:22	delta_time:3.20998	delta_time_per_sample:0.145908	used_time:40.9256	remain_time:12.0744	sample:48	frame_number:4
loop:4	sample_per_launch	:22	delta_time:3.20838	delta_time_per_sample:0.145835	used_time:44.134	remain_time:8.86598	sample:70	frame_number:5
loop:5	sample_per_launch	:22	delta_time:3.18738	delta_time_per_sample:0.144881	used_time:47.3214	remain_time:5.6786	sample:92	frame_number:6
loop:6	sample_per_launch	:22	delta_time:3.20014	delta_time_per_sample:0.145461	used_time:50.5215	remain_time:2.47846	sample:114	frame_number:7
[info] chnage sample_per_launch: 22 to 1
loop:7	sample_per_launch	:1	delta_time:0.25394	delta_time_per_sample:0.25394	used_time:50.7755	remain_time:2.22452	sample:115	frame_number:8
loop:8	sample_per_launch	:1	delta_time:0.24647	delta_time_per_sample:0.24647	used_time:51.0219	remain_time:1.97805	sample:116	frame_number:9
loop:9	sample_per_launch	:1	delta_time:0.251277	delta_time_per_sample:0.251277	used_time:51.2732	remain_time:1.72677	sample:117	frame_number:10
loop:10	sample_per_launch	:1	delta_time:0.257913	delta_time_per_sample:0.257913	used_time:51.5311	remain_time:1.46886	sample:118	frame_number:11
loop:11	sample_per_launch	:1	delta_time:0.249356	delta_time_per_sample:0.249356	used_time:51.7805	remain_time:1.21951	sample:119	frame_number:12
loop:12	sample_per_launch	:1	delta_time:0.259123	delta_time_per_sample:0.259123	used_time:52.0396	remain_time:0.960383	sample:120	frame_number:13
loop:13	sample_per_launch	:1	delta_time:0.247755	delta_time_per_sample:0.247755	used_time:52.2874	remain_time:0.712628	sample:121	frame_number:14
loop:14	sample_per_launch	:1	delta_time:0.25892	delta_time_per_sample:0.25892	used_time:52.5463	remain_time:0.453708	sample:122	frame_number:15
loop:15	sample_per_launch	:1	delta_time:0.24774	delta_time_per_sample:0.24774	used_time:52.794	remain_time:0.205968	sample:123	frame_number:16
[info] reached time limit! used_time: 52.794 sec. remain_time: 0.205968 sec.
[info] total_time: 78.2971 sec.
[info] total_sample: 124

</code>
</pre>
</details>


## RT_BUFFER_GPU_LOCAL 無効 --debug

### output

![output](https://user-images.githubusercontent.com/759115/65371952-490f5680-dca4-11e9-8fb2-f2f6c28c0c37.png)

### output png_albedo

![output png_albedo](https://user-images.githubusercontent.com/759115/65371954-4ca2dd80-dca4-11e9-8cba-181cf28744fe.png)

### output png_liner

![output png_liner](https://user-images.githubusercontent.com/759115/65371956-4f9dce00-dca4-11e9-8079-208377a52df4.png)

### output png_normal

![output png_normal](https://user-images.githubusercontent.com/759115/65371957-54628200-dca4-11e9-85b2-e3cc3cc70b21.png)

### output png_original

![output png_original](https://user-images.githubusercontent.com/759115/65371959-57f60900-dca4-11e9-8cdf-78bf4fb5ce40.png)

### output.log

[info] final_frame_rendering: 16.7169 sec.
[info] save_png: output.png	2.63262 sec.
[info] total_time: 81.9959 sec.
[info] total_sample: 129

<details>
<summary>output.log</summary>
<pre>
<code>
[info] getCuStringFromFile source_location: C:\Users\Administrator\Desktop\redflash_submit_v3.3\redflash_submit/redflash.cu
[info] getCuStringFromFile source_location: C:\Users\Administrator\Desktop\redflash_submit_v3.3\redflash_submit/cuda/redflash.cu
[info] getCuStringFromFile source_location: C:\Users\Administrator\Desktop\redflash_submit_v3.3\redflash_submit/intersect_raymarching.cu
[info] getCuStringFromFile source_location: C:\Users\Administrator\Desktop\redflash_submit_v3.3\redflash_submit/cuda/intersect_raymarching.cu
[info] getCuStringFromFile source_location: C:\Users\Administrator\Desktop\redflash_submit_v3.3\redflash_submit/intersect_sphere.cu
[info] getCuStringFromFile source_location: C:\Users\Administrator\Desktop\redflash_submit_v3.3\redflash_submit/cuda/intersect_sphere.cu
[info] resolvePath source_location: C:\Users\Administrator\Desktop\redflash_submit_v3.3\redflash_submit/cow.obj
[info] resolvePath source_location: C:\Users\Administrator\Desktop\redflash_submit_v3.3\redflash_submit/data/cow.obj
[info] getCuStringFromFile source_location: C:\Users\Administrator\Desktop\redflash_submit_v3.3\redflash_submit/triangle_mesh.cu
[info] getCuStringFromFile source_location: C:\Users\Administrator\Desktop\redflash_submit_v3.3\redflash_submit/cuda/triangle_mesh.cu
[info] resolvePath source_location: C:\Users\Administrator\Desktop\redflash_submit_v3.3\redflash_submit/metallic-lucy-statue-stanford-scan.obj
[info] resolvePath source_location: C:\Users\Administrator\Desktop\redflash_submit_v3.3\redflash_submit/data/metallic-lucy-statue-stanford-scan.obj
[info] resolvePath source_location: C:\Users\Administrator\Desktop\redflash_submit_v3.3\redflash_submit/Ice_Lake/Ice_Lake_Ref.hdr
[info] resolvePath source_location: C:\Users\Administrator\Desktop\redflash_submit_v3.3\redflash_submit/data/Ice_Lake/Ice_Lake_Ref.hdr
[info] resolution: 3840x2160 px
[info] time_limit: 53 sec.
[info] sample_per_launch: 4
[info] auto_set_sample_per_launch: 1
[info] auto_set_sample_per_launch_scale: 1
[info] last_frame_scale: 1.7
[info] tonemap_exposure: 2.5
[info] sample: INF(20)
loop:0	sample_per_launch	:4	delta_time:8.45895e-06	delta_time_per_sample:2.11474e-06	used_time:30.58	remain_time:22.42	sample:0	frame_number:1
loop:1	sample_per_launch	:4	delta_time:3.2099	delta_time_per_sample:0.802475	used_time:33.79	remain_time:19.21	sample:4	frame_number:2
[info] chnage sample_per_launch: 23 to 23
loop:2	sample_per_launch	:23	delta_time:3.32883	delta_time_per_sample:0.144732	used_time:37.1188	remain_time:15.8812	sample:27	frame_number:3
loop:3	sample_per_launch	:23	delta_time:3.33311	delta_time_per_sample:0.144918	used_time:40.4519	remain_time:12.5481	sample:50	frame_number:4
loop:4	sample_per_launch	:23	delta_time:3.31678	delta_time_per_sample:0.144208	used_time:43.7687	remain_time:9.23132	sample:73	frame_number:5
loop:5	sample_per_launch	:23	delta_time:3.3303	delta_time_per_sample:0.144795	used_time:47.099	remain_time:5.90102	sample:96	frame_number:6
loop:6	sample_per_launch	:23	delta_time:3.34324	delta_time_per_sample:0.145358	used_time:50.4422	remain_time:2.55778	sample:119	frame_number:7
[info] chnage sample_per_launch: 23 to 1
loop:7	sample_per_launch	:1	delta_time:0.256973	delta_time_per_sample:0.256973	used_time:50.6992	remain_time:2.30081	sample:120	frame_number:8
loop:8	sample_per_launch	:1	delta_time:0.245829	delta_time_per_sample:0.245829	used_time:50.945	remain_time:2.05498	sample:121	frame_number:9
loop:9	sample_per_launch	:1	delta_time:0.260833	delta_time_per_sample:0.260833	used_time:51.2059	remain_time:1.79415	sample:122	frame_number:10
loop:10	sample_per_launch	:1	delta_time:0.247532	delta_time_per_sample:0.247532	used_time:51.4534	remain_time:1.54661	sample:123	frame_number:11
loop:11	sample_per_launch	:1	delta_time:0.24289	delta_time_per_sample:0.24289	used_time:51.6963	remain_time:1.30372	sample:124	frame_number:12
loop:12	sample_per_launch	:1	delta_time:0.255104	delta_time_per_sample:0.255104	used_time:51.9514	remain_time:1.04862	sample:125	frame_number:13
loop:13	sample_per_launch	:1	delta_time:0.253042	delta_time_per_sample:0.253042	used_time:52.2044	remain_time:0.795577	sample:126	frame_number:14
loop:14	sample_per_launch	:1	delta_time:0.254427	delta_time_per_sample:0.254427	used_time:52.4588	remain_time:0.54115	sample:127	frame_number:15
loop:15	sample_per_launch	:1	delta_time:0.254961	delta_time_per_sample:0.254961	used_time:52.7138	remain_time:0.286189	sample:128	frame_number:16
[info] reached time limit! used_time: 52.7138 sec. remain_time: 0.286189 sec.
[info] final_frame_rendering: 16.7169 sec.
[info] save_png: output.png	2.63262 sec.
[info] save_png: output.png_original.png	2.68016 sec.
[info] save_png: output.png_albedo.png	0.792141 sec.
[info] save_png: output.png_normal.png	2.79023 sec.
[info] save_png: output.png_liner.png	2.38544 sec.
[info] total_time: 81.9959 sec.
[info] total_sample: 129

</code>
</pre>
</details>

# 検証環境: RTX2070

## bofore（レイトレ合宿7 提出版）--debug

### output.log

[info] total_time: 68.2637 sec.
[info] total_sample: 22

<details>
<summary>output.log</summary>
<pre>
<code>
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash_submit\redflash_submit/redflash.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash_submit\redflash_submit/cuda/redflash.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash_submit\redflash_submit/intersect_raymarching.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash_submit\redflash_submit/cuda/intersect_raymarching.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash_submit\redflash_submit/intersect_sphere.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash_submit\redflash_submit/cuda/intersect_sphere.cu
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash_submit\redflash_submit/cow.obj
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash_submit\redflash_submit/data/cow.obj
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash_submit\redflash_submit/triangle_mesh.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash_submit\redflash_submit/cuda/triangle_mesh.cu
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash_submit\redflash_submit/metallic-lucy-statue-stanford-scan.obj
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash_submit\redflash_submit/data/metallic-lucy-statue-stanford-scan.obj
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash_submit\redflash_submit/Ice_Lake/Ice_Lake_Ref.hdr
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash_submit\redflash_submit/data/Ice_Lake/Ice_Lake_Ref.hdr
[info] resolution: 3840x2160 px
[info] time_limit: 53 sec.
[info] sample_per_launch: 4
[info] auto_set_sample_per_launch: 1
[info] auto_set_sample_per_launch_scale: 1
[info] sample: INF(20)
loop:0	sample_per_launch	:4	delta_time:1.00001e-07	delta_time_per_sample:2.50002e-08	used_time:2.15259	remain_time:50.8474	sample:0	frame_number:1
loop:1	sample_per_launch	:4	delta_time:10.0326	delta_time_per_sample:2.50815	used_time:12.1852	remain_time:40.8148	sample:4	frame_number:2
[info] chnage sample_per_launch: 16 to 16
loop:2	sample_per_launch	:16	delta_time:40.9948	delta_time_per_sample:2.56218	used_time:53.18	remain_time:-0.180021	sample:20	frame_number:3
[info] chnage sample_per_launch: 16 to 1
loop:3	sample_per_launch	:1	delta_time:2.73282	delta_time_per_sample:2.73282	used_time:55.9128	remain_time:-2.91284	sample:21	frame_number:4
[info] reached time limit! used_time: 55.9128 sec. remain_time: -2.91284 sec.
[info] total_time: 68.2637 sec.
[info] total_sample: 22

</code>
</pre>
</details>

## RT_BUFFER_GPU_LOCAL 無効 --debug

### output.log

[info] final_frame_rendering: 4.5274 sec.
[info] save_png: output.png	1.62638 sec.
[info] save_png: output.png_original.png	1.67372 sec.
[info] save_png: output.png_albedo.png	0.549066 sec.
[info] save_png: output.png_normal.png	1.83458 sec.
[info] save_png: output.png_liner.png	1.48248 sec.
[info] total_time: 63.6992 sec.
[info] total_sample: 24

<details>
<summary>output.log</summary>
<pre>
<code>
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash_submit\redflash_submit/redflash.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash_submit\redflash_submit/cuda/redflash.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash_submit\redflash_submit/intersect_raymarching.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash_submit\redflash_submit/cuda/intersect_raymarching.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash_submit\redflash_submit/intersect_sphere.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash_submit\redflash_submit/cuda/intersect_sphere.cu
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash_submit\redflash_submit/cow.obj
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash_submit\redflash_submit/data/cow.obj
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash_submit\redflash_submit/triangle_mesh.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash_submit\redflash_submit/cuda/triangle_mesh.cu
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash_submit\redflash_submit/metallic-lucy-statue-stanford-scan.obj
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash_submit\redflash_submit/data/metallic-lucy-statue-stanford-scan.obj
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash_submit\redflash_submit/Ice_Lake/Ice_Lake_Ref.hdr
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash_submit\redflash_submit/data/Ice_Lake/Ice_Lake_Ref.hdr
[info] resolution: 3840x2160 px
[info] time_limit: 53 sec.
[info] sample_per_launch: 4
[info] auto_set_sample_per_launch: 1
[info] auto_set_sample_per_launch_scale: 1
[info] last_frame_scale: 1.7
[info] tonemap_exposure: 2.5
[info] sample: INF(20)
loop:0	sample_per_launch	:4	delta_time:1.90001e-06	delta_time_per_sample:4.75004e-07	used_time:1.91082	remain_time:51.0892	sample:0	frame_number:1
loop:1	sample_per_launch	:4	delta_time:9.10794	delta_time_per_sample:2.27699	used_time:11.0188	remain_time:41.9812	sample:4	frame_number:2
[info] chnage sample_per_launch: 18 to 18
loop:2	sample_per_launch	:18	delta_time:38.4346	delta_time_per_sample:2.13525	used_time:49.4533	remain_time:3.54667	sample:22	frame_number:3
[info] chnage sample_per_launch: 18 to 1
loop:3	sample_per_launch	:1	delta_time:2.36002	delta_time_per_sample:2.36002	used_time:51.8133	remain_time:1.18665	sample:23	frame_number:4
[info] reached time limit! used_time: 51.8133 sec. remain_time: 1.18665 sec.
[info] final_frame_rendering: 4.5274 sec.
[info] save_png: output.png	1.62638 sec.
[info] save_png: output.png_original.png	1.67372 sec.
[info] save_png: output.png_albedo.png	0.549066 sec.
[info] save_png: output.png_normal.png	1.83458 sec.
[info] save_png: output.png_liner.png	1.48248 sec.
[info] total_time: 63.6992 sec.
[info] total_sample: 24

</code>
</pre>
</details>