### PR TITLE
Refacotr Mandelbox

### DIFF
--- a/redflash/intersect_raymarching.cu
+++ b/redflash/intersect_raymarching.cu
@@ -16,7 +16,7 @@ rtDeclareVariable(float3, aabb_min, , );
 rtDeclareVariable(float3, aabb_max, , );
 rtDeclareVariable(float3, texcoord, attribute texcoord, );
 
-float dMenger(float3 z0, float3 offset, float scale) {
+RT_FUNCTION float dMenger(float3 z0, float3 offset, float scale) {
     float4 z = make_float4(z0, 1.0);
     for (int n = 0; n < 4; n++) {
         // z = abs(z);
@@ -62,19 +62,19 @@ float dMenger(float3 z0, float3 offset, float scale) {
     return (length(make_float3(max(abs(z.x) - 1.0, 0.0), max(abs(z.y) - 1.0, 0.0), max(abs(z.z) - 1.0, 0.0))) - 0.05) / z.w;
 }
 
-float3 get_xyz(float4 a)
+RT_FUNCTION float3 get_xyz(float4 a)
 {
     return make_float3(a.x, a.y, a.z);
 }
 
-void set_xyz(float4 &a, float3 b)
+RT_FUNCTION void set_xyz(float4 &a, float3 b)
 {
     a.x = b.x;
     a.y = b.y;
     a.z = b.z;
 }
 
-float dMandelFast(float3 p, float scale, int n) {
+RT_FUNCTION float dMandelFast(float3 p, float scale, int n) {
     float4 q0 = make_float4(p, 1.);
     float4 q = q0;
 

--- a/redflash/intersect_raymarching.cu
+++ b/redflash/intersect_raymarching.cu
@@ -62,17 +62,16 @@ float dMenger(float3 z0, float3 offset, float scale) {
     return (length(make_float3(max(abs(z.x) - 1.0, 0.0), max(abs(z.y) - 1.0, 0.0), max(abs(z.z) - 1.0, 0.0))) - 0.05) / z.w;
 }
 
-float3 get_xyz(float4 p)
+float3 get_xyz(float4 a)
 {
-    return make_float3(p.x, p.y, p.z);
+    return make_float3(a.x, a.y, a.z);
 }
 
-// not work...
 void set_xyz(float4 &a, float3 b)
 {
     a.x = b.x;
     a.y = b.y;
-    a.x = b.z;
+    a.z = b.z;
 }
 
 float dMandelFast(float3 p, float scale, int n) {
@@ -81,14 +80,11 @@ float dMandelFast(float3 p, float scale, int n) {
 
     for (int i = 0; i < n; i++) {
         // q.xyz = clamp(q.xyz, -1.0, 1.0) * 2.0 - q.xyz;
-        // set_xyz(q, clamp(get_xyz(q), -1.0, 1.0) * 2.0 - get_xyz(q));
-        float4 tmp = clamp(q, -1.0, 1.0) * 2.0 - q;
-        q.x = tmp.x;
-        q.y = tmp.y;
-        q.z = tmp.z;
+        float3 q_xyz = get_xyz(q);
+        set_xyz(q, clamp(q_xyz, -1.0, 1.0) * 2.0 - q_xyz);
 
         // q = q * scale / clamp( dot( q.xyz, q.xyz ), 0.3, 1.0 ) + q0;
-        float3 q_xyz = get_xyz(q);
+        q_xyz = get_xyz(q);
         q = q * scale / clamp(dot(q_xyz, q_xyz), 0.3, 1.0) + q0;
     }
 

--- a/redflash/intersect_raymarching.cu
+++ b/redflash/intersect_raymarching.cu
@@ -62,12 +62,12 @@ RT_FUNCTION float dMenger(float3 z0, float3 offset, float scale) {
     return (length(make_float3(max(abs(z.x) - 1.0, 0.0), max(abs(z.y) - 1.0, 0.0), max(abs(z.z) - 1.0, 0.0))) - 0.05) / z.w;
 }
 
-RT_FUNCTION float3 get_xyz(float4 a)
+RT_FUNCTION float3 get_xyz(const float4 &a)
 {
     return make_float3(a.x, a.y, a.z);
 }
 
-RT_FUNCTION void set_xyz(float4 &a, float3 b)
+RT_FUNCTION void set_xyz(float4 &a, const float3 &b)
 {
     a.x = b.x;
     a.y = b.y;


### PR DESCRIPTION
Mandelbox の定義をリファクタリング。

![pr42_v2](https://user-images.githubusercontent.com/759115/65416648-5149cc00-de33-11e9-976f-f9eedeedd740.png)
![pr42_v2 png_original](https://user-images.githubusercontent.com/759115/65416649-5149cc00-de33-11e9-81ee-f9bf50b0f16b.png)


<details>
<summary>v1 7a6eb05</summary>
<pre>
<code>
C:\Users\gam0022\Dropbox\redflash\build\bin\Release (master -> origin)
λ .\redflash.exe -f pr42_v1.png -W 1920 -H 1080 -t 57 -A 1.0 -S 4 --debug --denoise_mode 2
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/redflash.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/cuda/redflash.cu
[info] getCuStringFromFile source_location: C:/Users/gam0022/Dropbox/redflash/redflash/redflash.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/intersect_raymarching.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/cuda/intersect_raymarching.cu
[info] getCuStringFromFile source_location: C:/Users/gam0022/Dropbox/redflash/redflash/intersect_raymarching.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/intersect_sphere.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/cuda/intersect_sphere.cu
[info] getCuStringFromFile source_location: C:/Users/gam0022/Dropbox/redflash/redflash/intersect_sphere.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/bsdf_diffuse.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/cuda/bsdf_diffuse.cu
[info] getCuStringFromFile source_location: C:/Users/gam0022/Dropbox/redflash/redflash/bsdf_diffuse.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/bsdf_disney.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/cuda/bsdf_disney.cu
[info] getCuStringFromFile source_location: C:/Users/gam0022/Dropbox/redflash/redflash/bsdf_disney.cu
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/cow.obj
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/data/cow.obj
[info] resolvePath source_location: C:/Users/gam0022/Dropbox/redflash/data/cow.obj
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/triangle_mesh.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/cuda/triangle_mesh.cu
[info] getCuStringFromFile source_location: C:/Users/gam0022/Dropbox/redflash/cuda/triangle_mesh.cu
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/metallic-lucy-statue-stanford-scan.obj
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/data/metallic-lucy-statue-stanford-scan.obj
[info] resolvePath source_location: C:/Users/gam0022/Dropbox/redflash/data/metallic-lucy-statue-stanford-scan.obj
WARN: Material file [ C:/Users/gam0022/Dropbox/redflash/data/metallic-lucy-statue-stanford-scan.mtl ] not found. Created a default material.
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/Ice_Lake/Ice_Lake_Ref.hdr
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/data/Ice_Lake/Ice_Lake_Ref.hdr
[info] resolvePath source_location: C:/Users/gam0022/Dropbox/redflash/data/Ice_Lake/Ice_Lake_Ref.hdr
[info] resolution: 1920x1080 px
[info] time_limit: 57 sec.
[info] sample_per_launch: 4
[info] auto_set_sample_per_launch: 1
[info] auto_set_sample_per_launch_scale: 1
[info] last_frame_scale: 1.7
[info] tonemap_exposure: 2.5
[info] sample: INF(20)
loop:0  sample_per_launch       :4      delta_time:1.00001e-07  delta_time_per_sample:2.50002e-08       used_time:2.23144       remain_time:54.7686     sample:0        frame_number:1
loop:1  sample_per_launch       :4      delta_time:2.84453      delta_time_per_sample:0.711132  used_time:5.07597       remain_time:51.924      sample:4        frame_number:2
[info] chnage sample_per_launch: 73 to 73
loop:2  sample_per_launch       :73     delta_time:38.3889      delta_time_per_sample:0.525876  used_time:43.4649       remain_time:13.5351     sample:77       frame_number:3
[info] chnage sample_per_launch: 73 to 1
loop:3  sample_per_launch       :1      delta_time:0.589691     delta_time_per_sample:0.589691  used_time:44.0546       remain_time:12.9454     sample:78       frame_number:4
loop:4  sample_per_launch       :1      delta_time:0.588556     delta_time_per_sample:0.588556  used_time:44.6432       remain_time:12.3568     sample:79       frame_number:5
loop:5  sample_per_launch       :1      delta_time:0.578972     delta_time_per_sample:0.578972  used_time:45.2221       remain_time:11.7779     sample:80       frame_number:6
loop:6  sample_per_launch       :1      delta_time:0.586296     delta_time_per_sample:0.586296  used_time:45.8084       remain_time:11.1916     sample:81       frame_number:7
loop:7  sample_per_launch       :1      delta_time:0.580716     delta_time_per_sample:0.580716  used_time:46.3891       remain_time:10.6109     sample:82       frame_number:8
loop:8  sample_per_launch       :1      delta_time:0.580853     delta_time_per_sample:0.580853  used_time:46.97 remain_time:10.03       sample:83       frame_number:9
loop:9  sample_per_launch       :1      delta_time:0.574132     delta_time_per_sample:0.574132  used_time:47.5441       remain_time:9.45588     sample:84       frame_number:10
loop:10 sample_per_launch       :1      delta_time:0.582246     delta_time_per_sample:0.582246  used_time:48.1264       remain_time:8.87363     sample:85       frame_number:11
loop:11 sample_per_launch       :1      delta_time:0.580701     delta_time_per_sample:0.580701  used_time:48.7071       remain_time:8.29293     sample:86       frame_number:12
loop:12 sample_per_launch       :1      delta_time:0.577957     delta_time_per_sample:0.577957  used_time:49.285        remain_time:7.71497     sample:87       frame_number:13
loop:13 sample_per_launch       :1      delta_time:0.581684     delta_time_per_sample:0.581684  used_time:49.8667       remain_time:7.13329     sample:88       frame_number:14
loop:14 sample_per_launch       :1      delta_time:0.584748     delta_time_per_sample:0.584748  used_time:50.4515       remain_time:6.54854     sample:89       frame_number:15
loop:15 sample_per_launch       :1      delta_time:0.585321     delta_time_per_sample:0.585321  used_time:51.0368       remain_time:5.96322     sample:90       frame_number:16
loop:16 sample_per_launch       :1      delta_time:0.580287     delta_time_per_sample:0.580287  used_time:51.6171       remain_time:5.38293     sample:91       frame_number:17
loop:17 sample_per_launch       :1      delta_time:0.587784     delta_time_per_sample:0.587784  used_time:52.2049       remain_time:4.79515     sample:92       frame_number:18
loop:18 sample_per_launch       :1      delta_time:0.580127     delta_time_per_sample:0.580127  used_time:52.785        remain_time:4.21502     sample:93       frame_number:19
loop:19 sample_per_launch       :1      delta_time:0.585646     delta_time_per_sample:0.585646  used_time:53.3706       remain_time:3.62937     sample:94       frame_number:20
loop:20 sample_per_launch       :1      delta_time:0.583349     delta_time_per_sample:0.583349  used_time:53.954        remain_time:3.04603     sample:95       frame_number:21
loop:21 sample_per_launch       :1      delta_time:0.591107     delta_time_per_sample:0.591107  used_time:54.5451       remain_time:2.45492     sample:96       frame_number:22
loop:22 sample_per_launch       :1      delta_time:0.578487     delta_time_per_sample:0.578487  used_time:55.1236       remain_time:1.87643     sample:97       frame_number:23
loop:23 sample_per_launch       :1      delta_time:0.585543     delta_time_per_sample:0.585543  used_time:55.7091       remain_time:1.29089     sample:98       frame_number:24
loop:24 sample_per_launch       :1      delta_time:0.589496     delta_time_per_sample:0.589496  used_time:56.2986       remain_time:0.701393    sample:99       frame_number:25
[info] reached time limit! used_time: 56.2986 sec. remain_time: 0.701393 sec.
[info] final_frame_rendering: 2.1018 sec.
[info] save_png: pr42_v1.png    0.433677 sec.
[info] save_png: pr42_v1.png_original.png       0.419533 sec.
[info] save_png: pr42_v1.png_albedo.png 0.1404 sec.
[info] save_png: pr42_v1.png_normal.png 0.431288 sec.
[info] save_png: pr42_v1.png_liner.png  0.395455 sec.
[info] total_time: 60.2884 sec.
[info] total_sample: 100
</code>
</pre>
</details>

<details>
<summary>v2 98e83d5</summary>
<pre>
<code>C:\Users\gam0022\Dropbox\redflash\build\bin\Release (refactor-mandelbox-define -> origin)
λ .\redflash.exe -f pr42_v2.png -W 1920 -H 1080 -t 57 -A 1.0 -S 4 --debug --denoise_mode 2
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/redflash.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/cuda/redflash.cu
[info] getCuStringFromFile source_location: C:/Users/gam0022/Dropbox/redflash/redflash/redflash.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/intersect_raymarching.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/cuda/intersect_raymarching.cu
[info] getCuStringFromFile source_location: C:/Users/gam0022/Dropbox/redflash/redflash/intersect_raymarching.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/intersect_sphere.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/cuda/intersect_sphere.cu
[info] getCuStringFromFile source_location: C:/Users/gam0022/Dropbox/redflash/redflash/intersect_sphere.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/bsdf_diffuse.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/cuda/bsdf_diffuse.cu
[info] getCuStringFromFile source_location: C:/Users/gam0022/Dropbox/redflash/redflash/bsdf_diffuse.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/bsdf_disney.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/cuda/bsdf_disney.cu
[info] getCuStringFromFile source_location: C:/Users/gam0022/Dropbox/redflash/redflash/bsdf_disney.cu
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/cow.obj
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/data/cow.obj
[info] resolvePath source_location: C:/Users/gam0022/Dropbox/redflash/data/cow.obj
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/triangle_mesh.cu
[info] getCuStringFromFile source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/cuda/triangle_mesh.cu
[info] getCuStringFromFile source_location: C:/Users/gam0022/Dropbox/redflash/cuda/triangle_mesh.cu
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/metallic-lucy-statue-stanford-scan.obj
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/data/metallic-lucy-statue-stanford-scan.obj
[info] resolvePath source_location: C:/Users/gam0022/Dropbox/redflash/data/metallic-lucy-statue-stanford-scan.obj
WARN: Material file [ C:/Users/gam0022/Dropbox/redflash/data/metallic-lucy-statue-stanford-scan.mtl ] not found. Created a default material.
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/Ice_Lake/Ice_Lake_Ref.hdr
[info] resolvePath source_location: C:\Users\gam0022\Dropbox\redflash\build\bin\Release/data/Ice_Lake/Ice_Lake_Ref.hdr
[info] resolvePath source_location: C:/Users/gam0022/Dropbox/redflash/data/Ice_Lake/Ice_Lake_Ref.hdr
[info] resolution: 1920x1080 px
[info] time_limit: 57 sec.
[info] sample_per_launch: 4
[info] auto_set_sample_per_launch: 1
[info] auto_set_sample_per_launch_scale: 1
[info] last_frame_scale: 1.7
[info] tonemap_exposure: 2.5
[info] sample: INF(20)
loop:0  sample_per_launch       :4      delta_time:2.00002e-07  delta_time_per_sample:5.00004e-08       used_time:2.17235       remain_time:54.8277     sample:0        frame_number:1
loop:1  sample_per_launch       :4      delta_time:2.39465      delta_time_per_sample:0.598662  used_time:4.567 remain_time:52.433      sample:4        frame_number:2
[info] chnage sample_per_launch: 87 to 87
loop:2  sample_per_launch       :87     delta_time:48.1274      delta_time_per_sample:0.553188  used_time:52.6944       remain_time:4.30562     sample:91       frame_number:3
[info] chnage sample_per_launch: 87 to 1
loop:3  sample_per_launch       :1      delta_time:0.581678     delta_time_per_sample:0.581678  used_time:53.2761       remain_time:3.72394     sample:92       frame_number:4
loop:4  sample_per_launch       :1      delta_time:0.612522     delta_time_per_sample:0.612522  used_time:53.8886       remain_time:3.11142     sample:93       frame_number:5
loop:5  sample_per_launch       :1      delta_time:0.66725      delta_time_per_sample:0.66725   used_time:54.5558       remain_time:2.44417     sample:94       frame_number:6
loop:6  sample_per_launch       :1      delta_time:0.669563     delta_time_per_sample:0.669563  used_time:55.2254       remain_time:1.77461     sample:95       frame_number:7
loop:7  sample_per_launch       :1      delta_time:0.605199     delta_time_per_sample:0.605199  used_time:55.8306       remain_time:1.16941     sample:96       frame_number:8
loop:8  sample_per_launch       :1      delta_time:0.644041     delta_time_per_sample:0.644041  used_time:56.4746       remain_time:0.525366    sample:97       frame_number:9
[info] reached time limit! used_time: 56.4746 sec. remain_time: 0.525366 sec.
[info] final_frame_rendering: 1.85493 sec.
[info] save_png: pr42_v2.png    0.457108 sec.
[info] save_png: pr42_v2.png_original.png       0.445507 sec.
[info] save_png: pr42_v2.png_albedo.png 0.137216 sec.
[info] save_png: pr42_v2.png_normal.png 0.463826 sec.
[info] save_png: pr42_v2.png_liner.png  0.416666 sec.
[info] total_time: 60.3118 sec.
[info] total_sample: 98
</code>
</pre>
</details>